### PR TITLE
Fix invalid-server error

### DIFF
--- a/Gateway/MailChimpSubscriberGateway.php
+++ b/Gateway/MailChimpSubscriberGateway.php
@@ -19,12 +19,15 @@ class MailChimpSubscriberGateway implements SubscriberGateway
      */
     protected $api;
 
-    public function __construct(string $apiKey)
-    {
+    public function __construct(
+        string $apiKey,
+        string $server
+    ) {
         $this->api = new ApiClient();
 
         $this->api->setConfig([
             'apiKey' => $apiKey,
+            'server' => $server,
         ]);
     }
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ public function registerBundles()
 ```yaml
 mailmotor.mail_engine:  'mailchimp'
 mailmotor.api_key:      xxx # enter your mailchimp api_key here
+mailmotor.server:       xxx # enter your mailchimp server prefix here (f.e. us1)
 mailmotor.list_id:      xxx # enter the mailchimp default list_id here
 ```
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,5 +4,6 @@ services:
         class: MailMotor\Bundle\MailChimpBundle\Gateway\MailChimpSubscriberGateway
         arguments:
             - "%mailmotor.api_key%"
+            - "%mailmotor.server%"
         tags:
             - { name: mailmotor.subscriber_gateway, alias: mailchimp }


### PR DESCRIPTION
Not sure how long this error has existed (I assume since moving to Mailchimps original library) but when trying to subscribe an error popped up that the connection to `invalid-server.api.mailchimp.com` couldn't be established.

When looking at their documentation it states the following under [Authentication Methods](https://github.com/mailchimp/mailchimp-marketing-php/tree/c1a38f7248d8de7de412418fed8dae759b9e4b97?tab=readme-ov-file#authentication-methods):

> For either method, a server prefix should be passed in i.e. us19, in order for the client to determine to appropriate host url.

With the following changes a server prefix is required and subscribing works as expected again.